### PR TITLE
Improve hermeticity

### DIFF
--- a/cc_toolchain/cc_toolchain_import.bzl
+++ b/cc_toolchain/cc_toolchain_import.bzl
@@ -137,18 +137,22 @@ def _cc_toolchain_import_impl(ctx):
         depset(
             shared_library_list,
             transitive = transitive_shared_libraries,
+            order = "topological",
         ),
         depset(
             static_library_list,
             transitive = transitive_static_libraries,
+            order = "topological",
         ),
         depset(
             runtime_paths,
             transitive = transitive_runtime_paths,
+            order = "topological",
         ),
         depset(
             ctx.files.additional_libs,
             transitive = transitive_additional_libs,
+            order = "topological",
         ),
     )
     library_files = []
@@ -169,6 +173,7 @@ def _cc_toolchain_import_impl(ctx):
                                          transitive_hdrs +
                                          transitive_additional_libs +
                                          transitive_injected_hdrs,
+                            order = "topological",
                         )),
         _cc_toolchain_import(compilation_context, linking_context),
     ]

--- a/cc_toolchain/features/features.bzl
+++ b/cc_toolchain/features/features.bzl
@@ -153,6 +153,10 @@ def _cc_toolchain_import_feature_impl(ctx):
         "-L" + file.dirname
         for file in toolchain_import_info
             .linking_context.dynamic_libraries.to_list()
+    ] + [
+        "-L" + file.dirname
+        for file in toolchain_import_info
+            .linking_context.additional_libs.to_list()
     ]).to_list()
 
     lib_prefix = "lib"

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -29,6 +29,13 @@ alias(
 )
 
 alias(
+    name = "pthread_multiplexer",
+    actual = select({
+        ":linux_x86_64": "@debian_stretch_amd64_sysroot//:pthread",
+    }),
+)
+
+alias(
     name = "libc++_multiplexer",
     actual = select({
         ":linux_x86_64": "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:llvm_libcxx",

--- a/config/rules_cc_toolchain_config.BUILD
+++ b/config/rules_cc_toolchain_config.BUILD
@@ -13,6 +13,11 @@ label_flag(
 )
 
 label_flag(
+    name = "libpthread",
+    build_setting_default = "@rules_cc_toolchain//config:pthread_multiplexer",
+)
+
+label_flag(
     name = "libunwind",
     build_setting_default = "@rules_cc_toolchain//config:libunwind_multiplexer",
 )

--- a/third_party/clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD
+++ b/third_party/clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD
@@ -66,9 +66,6 @@ cc_toolchain_import(
 cc_toolchain_import(
     name = "llvm_libcxx",
     hdrs = glob(["include/c++/v1/**"]),
-    additional_libs = [
-        "lib/libc++.so.1",
-    ],
     includes = ["include/c++/v1"],
     static_library = "lib/libc++.a",
     target_compatible_with = select({
@@ -94,6 +91,7 @@ cc_toolchain_import(
     visibility = ["@rules_cc_toolchain//config:__pkg__"],
     deps = [
         "@rules_cc_toolchain_config//:libc",
+        "@rules_cc_toolchain_config//:libpthread",
     ],
 )
 

--- a/third_party/debian_stretch_amd64_sysroot.BUILD
+++ b/third_party/debian_stretch_amd64_sysroot.BUILD
@@ -44,7 +44,10 @@ cc_toolchain_import(
 
 cc_toolchain_import(
     name = "gcc",
-    additional_libs = ["usr/lib/gcc/x86_64-linux-gnu/6/libgcc_s.so.1"],
+    additional_libs = [
+        "usr/lib/gcc/x86_64-linux-gnu/6/libgcc_s.so.1",
+        "usr/lib/gcc/x86_64-linux-gnu/6/libgcc_eh.a",
+    ],
     runtime_path = "/usr/lib/x86_64-linux-gnu",
     shared_library = "usr/lib/gcc/x86_64-linux-gnu/6/libgcc_s.so",
     static_library = "usr/lib/gcc/x86_64-linux-gnu/6/libgcc.a",
@@ -57,7 +60,11 @@ cc_toolchain_import(
 
 cc_toolchain_import(
     name = "mvec",
-    additional_libs = ["usr/lib/x86_64-linux-gnu/libmvec_nonshared.a"],
+    additional_libs = [
+        "lib/x86_64-linux-gnu/libmvec-2.24.so",
+        "lib/x86_64-linux-gnu/libmvec.so.1",
+        "usr/lib/x86_64-linux-gnu/libmvec_nonshared.a",
+    ],
     shared_library = "usr/lib/x86_64-linux-gnu/libmvec.so",
     static_library = "usr/lib/x86_64-linux-gnu/libmvec.a",
     target_compatible_with = select({
@@ -68,16 +75,23 @@ cc_toolchain_import(
 
 cc_toolchain_import(
     name = "dynamic_linker",
+    additional_libs = [
+        "lib64/ld-linux-x86-64.so.2",
+        "lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
+    ],
+    runtime_path = "/lib64",
     shared_library = "usr/lib/x86_64-linux-gnu/libdl.so",
     static_library = "usr/lib/x86_64-linux-gnu/libdl.a",
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    deps = [":libc"],
 )
 
 cc_toolchain_import(
     name = "math",
+    additional_libs = ["lib/x86_64-linux-gnu/libm.so.6"],
     shared_library = "usr/lib/x86_64-linux-gnu/libm.so",
     static_library = "usr/lib/x86_64-linux-gnu/libm.a",
     target_compatible_with = select({
@@ -88,14 +102,22 @@ cc_toolchain_import(
 
 cc_toolchain_import(
     name = "pthread",
-    additional_libs = ["usr/lib/x86_64-linux-gnu/libpthread_nonshared.a"],
+    additional_libs = [
+        "lib/x86_64-linux-gnu/libpthread.so.0",
+        "lib/x86_64-linux-gnu/libpthread-2.24.so",
+        "usr/lib/x86_64-linux-gnu/libpthread_nonshared.a",
+    ],
     shared_library = "usr/lib/x86_64-linux-gnu/libpthread.so",
     static_library = "usr/lib/x86_64-linux-gnu/libpthread.a",
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    deps = [":rt"],
+    visibility = ["@rules_cc_toolchain//config:__pkg__"],
+    deps = [
+        ":libc",
+        ":rt",
+    ],
 )
 
 cc_toolchain_import(
@@ -112,9 +134,15 @@ cc_toolchain_import(
 )
 
 cc_toolchain_import(
-    name = "glibc",
+    name = "libc",
     hdrs = glob([inc + "/**/*.h" for inc in INCLUDES] + [inc + "/*.h" for inc in INCLUDES]),
+    additional_libs = [
+        "lib/x86_64-linux-gnu/libc.so.6",
+        "lib/x86_64-linux-gnu/libc-2.24.so",
+        "usr/lib/x86_64-linux-gnu/libc_nonshared.a",
+    ],
     includes = INCLUDES,
+    runtime_path = "/usr/lib/gcc/x86_64-linux-gnu/6",
     shared_library = "usr/lib/x86_64-linux-gnu/libc.so",
     static_library = "usr/lib/x86_64-linux-gnu/libc.a",
     target_compatible_with = select({
@@ -123,11 +151,26 @@ cc_toolchain_import(
     }),
     visibility = ["@rules_cc_toolchain//config:__pkg__"],
     deps = [
-        ":dynamic_linker",
         ":gcc",
         ":math",
         ":mvec",
-        ":pthread",
+        "@rules_cc_toolchain_config//:compiler_rt",
+    ],
+)
+
+# This is a group of all the system libraries we need. The actual glibc library is split
+# out to fix link ordering problems that cause false undefined symbol positives.
+cc_toolchain_import(
+    name = "glibc",
+    runtime_path = "/lib/x86_64-linux-gnu",
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["@rules_cc_toolchain//config:__pkg__"],
+    deps = [
+        ":dynamic_linker",
+        ":libc",
         "@rules_cc_toolchain_config//:compiler_rt",
     ],
 )


### PR DESCRIPTION
This fixes a number of link-related build hermeticity issues.

- Link order was not topological for some things, which caused symbols that existed in some linked libraries to not be found due to bad link order.
- Some dependencies weren't quite right.
- Some required libraries were missing from the build files.
- Some library/rpath directories were missing from the linker invocation.